### PR TITLE
Update ha_startup.script

### DIFF
--- a/scripts/ha_startup.script
+++ b/scripts/ha_startup.script
@@ -200,10 +200,5 @@
 /log warning "ha_startup: DONE"
 :put "ha_startup: DONE"
 
-#} on-error={
-#   /log warning "ha_startup: FAILED got error! disabling all interfaces!"
-#   /interface ethernet disable [find]
-#}
-
 :do { :local k [/system script find name="on_startup"]; if ([:len $k] = 1) do={ /system script run $k } } on-error={ :put "on_startup failed" }
 }

--- a/scripts/ha_startup.script
+++ b/scripts/ha_startup.script
@@ -6,7 +6,6 @@
 :global uptime [/system resource get uptime]
 :if (!$haAllowBootstrap && ([:typeof $haStartupHasRun] != "nothing" || uptime > 2m)) do={
    /log warning "ha_startup: ERROR ATTEMPTED TO RUN AGAIN!!! $haStartupHasRun $uptime"
-   :error "ha_startup: ERROR ATTEMPTED TO RUN AGAIN!!! $haStartupHasRun $uptime"
 } else={
 :set haStartupHasRun [/system resource get uptime]
 :set haAllowBootstrap false


### PR DESCRIPTION
Mikrotik scripting engine still executes this part, the scripting engine ignores the #tag because of the curly braces following it.

Output from HA_boot_log after a crash:

02:40:03 script,warning ha_startup: ERROR ATTEMPTED TO RUN AGAIN!!!  1d01:40:30 
2:40:08 interface,info sfp-sfpplus1 link down 
02:40:08 system,info device changed by admin 
02:40:08 interface,info UPLINK link down 
02:40:08 interface,info sfp-sfpplus2 link down 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 interface,info sfp-sfpplus3 link down 
02:40:09 system,info device changed by admin 
02:40:09 interface,info sfp-sfpplus4 link down 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 interface,info sfp-sfpplus10 link down 
02:40:09 interface,info sfp-sfpplus11 link down 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 system,info device changed by admin 
02:40:09 interface,info sfp28-1 link down 
02:40:10 script,error ha_startup: FAILED - DISABLED ALL INTERFACES 
02:40:10 system,info device changed by admin 
02:40:10 interface,info sfp28-2 link down